### PR TITLE
http-conduit benchmark improvements

### DIFF
--- a/tests/ComparisonBenchmark.hs
+++ b/tests/ComparisonBenchmark.hs
@@ -21,12 +21,14 @@ import GHC.Conc
 
 import ConduitSample (sampleViaHttpConduit)
 import StreamsSample (sampleViaHttpStreams)
+import Network.HTTP.Conduit (def, newManager)
 
 main :: IO ()
 main = do
     GHC.Conc.setNumCapabilities 4
+    man <- newManager def
     defaultMain
        [bench "http-streams" (sampleViaHttpStreams),
-        bench "http-conduit" (sampleViaHttpConduit)]
+        bench "http-conduit" (sampleViaHttpConduit man)]
     putStrLn "Complete."
 


### PR DESCRIPTION
As I mentioned in my email. The changes I made (with relative performance)
- Initial code: 23% difference
- Without timeouts: 12%
- Single source: 10%
- Create the Manager externally: http-conduit is 2% faster.
