### PR TITLE
Duplicate headers not concatonated

### DIFF
--- a/tests/Check.hs
+++ b/tests/Check.hs
@@ -75,6 +75,7 @@ suite = do
         testChunkedEncoding
         testContentLength
         testCompressedResponse
+        testMultilineResponseHeaders
 
     describe "Expectation handling" $ do
         testExpectationContinue
@@ -424,6 +425,15 @@ testExcessiveRedirects =
         handler _ _ = do
             assertBool "Should have thrown exception before getting here" False
 
+testMultilineResponseHeaders =
+    it "multiline response headers are properly parsed" $ do
+        let url = S.concat ["http://", localhost, "/multilineheaders"]
+
+        get url handler
+      where
+        handler :: Response -> InputStream ByteString -> IO ()
+        handler r _ = do
+            assertEqual "Invalid response headers" (Just "line1\nline2") (getHeader r "Set-Cookie")
 
 {-
     From http://stackoverflow.com/questions/6147435/is-there-an-assertexception-in-any-of-the-haskell-test-frameworks

--- a/tests/TestServer.hs
+++ b/tests/TestServer.hs
@@ -76,7 +76,8 @@ routeRequests =
              ("bounce", serveRedirect),
              ("loop", serveRedirectEndlessly),
              ("postbox", method POST handlePostMethod),
-             ("size", handleSizeRequest)]
+             ("size", handleSizeRequest),
+             ("multilineheaders", serveMultilineResponseHeaders)]
     <|> serveNotFound
 
 
@@ -157,6 +158,11 @@ serveRedirectEndlessly = do
   where
     r' = S.concat ["http://", localHost, ":", S.pack $ show $ localPort, "/loop"]
 
+
+serveMultilineResponseHeaders :: Snap ()
+serveMultilineResponseHeaders = do
+    modifyResponse $ addHeader "Set-Cookie" "line1"
+    modifyResponse $ addHeader "Set-Cookie" "line2"
 
 handlePostMethod :: Snap ()
 handlePostMethod = do


### PR DESCRIPTION
adds a (failing) test for properly parsing multi-line response headers
