### PR TITLE
Fixes #18: segfault during SSL connections

### DIFF
--- a/src/Network/Http/Client.hs
+++ b/src/Network/Http/Client.hs
@@ -158,7 +158,6 @@ module Network.Http.Client (
     -- * Secure connections
     openConnectionSSL,
     baselineContextSSL,
-    modifyContextSSL,
     establishConnection,
 
     -- * Testing support


### PR DESCRIPTION
Segfaults were occurring on SSL connections due to the lack of using `withOpenSSL` monad.
