### PR TITLE
Revised fix for #18

### DIFF
--- a/src/Network/Http/Client.hs
+++ b/src/Network/Http/Client.hs
@@ -158,7 +158,7 @@ module Network.Http.Client (
     -- * Secure connections
     openConnectionSSL,
     baselineContextSSL,
-    modifyContextSSL,
+    -- modifyContextSSL,
     establishConnection,
 
     -- * Testing support


### PR DESCRIPTION
# What it fixes

The usage of the convenience functions to retrieve a resource:
`resp <- get url concatHandler`

In particular, when an HTTPS resource scheme is provided. The HsOpenSSL library only works if the request is wrapped in an `withOpenSSL` computation. The intended effect however is to not require the programmer to do anything specifically different if providing an HTTPS scheme vs. an HTTP scheme.

The default behavior (without `withOpenSSL`) ends in a segmentation fault and to fix that the request needs to be explicitly wrapped, which makes the original intention of the convenience functions moot.

This fixes that, by wrapping ONLY the connection builder that was branched from a match on an HTTPS scheme in the URI.

The only problem is the inability to modify the OpenSSL context created **before** the request is made; however, if the user needs that ability it would be easy to build what they need on their own or revise this current solution to enable the user to pass their own SSL context through the convenience functions (modifying which ciphers are used, cert checking, cert locations, etc...).
