### PR TITLE
Allow other methods to send bodies

### DIFF
--- a/src/Network/Http/RequestBuilder.hs
+++ b/src/Network/Http/RequestBuilder.hs
@@ -100,9 +100,8 @@ http m p' = do
 
     let e  = case m of
             GET   -> Empty
-            POST  -> Chunking
-            PUT   -> Chunking
-            _     -> Empty
+            TRACE -> Empty
+            _     -> Chunking
 
     let h3 = case e of
             Chunking    -> updateHeader h2 "Transfer-Encoding" "chunked"


### PR DESCRIPTION
As best I can sell, the only methods that really shouldn't be sending
bodies are TRACE and GET. This patch solves #29 and allow methods other
than those two to send bodies.
