### PR TITLE
Expose exceptions tycons, so we can catch them.

### DIFF
--- a/src/Network/Http/Client.hs
+++ b/src/Network/Http/Client.hs
@@ -137,6 +137,7 @@ module Network.Http.Client (
     debugHandler,
     concatHandler,
     concatHandler',
+    HttpClientError,
     jsonHandler,
 
     -- * Resource cleanup
@@ -155,6 +156,7 @@ module Network.Http.Client (
     --
     URL,
     get,
+    TooManyRedirects,
     post,
     postForm,
     put,

--- a/src/Network/Http/Connection.hs
+++ b/src/Network/Http/Connection.hs
@@ -27,6 +27,7 @@ module Network.Http.Connection (
     sendRequest,
     receiveResponse,
     receiveResponseRaw,
+    UnexpectedCompression,
     emptyBody,
     fileBody,
     inputStreamBody,
@@ -398,6 +399,9 @@ getHeadersFull c q =
 --
 -- The final value from the handler function is the return value of
 -- @receiveResponse@, if you need it.
+--
+-- Throws 'UnexpectedCompression' if it doesn't know how to handle the
+-- compression format used in the response.
 --
 {-
     The reponse body coming from the server MUST be fully read, even

--- a/src/Network/Http/Inconvenience.hs
+++ b/src/Network/Http/Inconvenience.hs
@@ -28,11 +28,9 @@ module Network.Http.Inconvenience (
     baselineContextSSL,
     concatHandler',
     jsonHandler,
-
-    -- for testing
-    TooManyRedirects(..),
-    HttpClientError(..),
-    splitURI
+    TooManyRedirects(..),       -- Constructor used in tests
+    HttpClientError(..),        -- Constructor used in tests
+    splitURI                    -- Used in tests
 ) where
 
 #include "config.h"
@@ -288,6 +286,8 @@ path u = case url of
 -- but for anything more refined you'll find it easy to simply write
 -- your own handler function.
 --
+-- Throws 'TooManyRedirects' if more than 5 redirects are thrown.
+--
 get :: URL
     -- ^ Resource to GET from.
     -> (Response -> InputStream ByteString -> IO β)
@@ -516,8 +516,8 @@ put r' t body handler = do
 
 --
 -- | A special case of 'concatHandler', this function will return the
--- entire response body as a single ByteString, but will throw an
--- exception if the response status code was other than @2xx@.
+-- entire response body as a single ByteString, but will throw
+-- 'HttpClientError' if the response status code was other than @2xx@.
 --
 concatHandler' :: Response -> InputStream ByteString -> IO ByteString
 concatHandler' p i =

--- a/src/Network/Http/ResponseParser.hs
+++ b/src/Network/Http/ResponseParser.hs
@@ -22,6 +22,7 @@
 module Network.Http.ResponseParser (
     readResponseHeader,
     readResponseBody,
+    UnexpectedCompression,
 
         -- for testing
     readDecimal


### PR DESCRIPTION
Otherwise the only option to write exception-safe code is `SomeException`.
