### PR TITLE
Fix URL encoding.

### DIFF
--- a/src/Network/Http/Inconvenience.hs
+++ b/src/Network/Http/Inconvenience.hs
@@ -47,7 +47,7 @@ import Data.Bits (Bits (..))
 import Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as S
 import Data.ByteString.Internal (c2w, w2c)
-import Data.Char (intToDigit, isAlphaNum)
+import Data.Char (intToDigit)
 import Data.HashSet (HashSet)
 import qualified Data.HashSet as HashSet
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
@@ -122,7 +122,10 @@ hexd c0 = Builder.fromWord8 (c2w '%') `mappend` Builder.fromWord8 hi
 urlEncodeTable :: HashSet Char
 urlEncodeTable = HashSet.fromList $! filter f $! map w2c [0..255]
   where
-    f c = isAlphaNum c || elem c "$-.!*'(),"
+    f c | c >= 'A' && c <= 'Z' = True
+        | c >= 'a' && c <= 'z' = True
+        | c >= '0' && c <= '9' = True
+    f c = c `elem` "$-_.!~*'(),"
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
It seems that due to the use of `Data.Char.isAlphaNum`, which returns `True` for characters outside of the ASCII range, many bytes are not correctly encoded.

For example, `ø` in utf8 encodes to `\195\184` and since `isAlphaNum '\195' == True`, the (incorrect) result was `\195%b8`.

This patch fixes the issue and also adds `_` and `~` to the list of characters not needing any encoding as they appear in the list of unreserved characters according to [RFC2396](http://tools.ietf.org/html/rfc2396.html#section-2.3) and should thus never be encoded.
