### PR TITLE
Make requestBuilder a pure function

### DIFF
--- a/http-streams.cabal
+++ b/http-streams.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >= 1.10
 name:                http-streams
-version:             0.7.2.0
+version:             0.8.0.1
 synopsis:            An HTTP client using io-streams
 description:
  /Overview/
@@ -30,7 +30,7 @@ library
   default-language:  Haskell2010
 
   build-depends:     attoparsec,
-                     http-common >= 0.7.1,
+                     http-common >= 0.8.0,
                      base >= 4 && <5,
                      directory,
                      base64-bytestring,
@@ -74,7 +74,6 @@ test-suite           check
   default-language:  Haskell2010
 
   build-depends:
-                     http-common,
                      HUnit,
                      HsOpenSSL,
                      MonadCatchIO-transformers,
@@ -100,9 +99,11 @@ test-suite           check
                      system-filepath >= 0.4.1  && < 0.5,
                      text,
                      unordered-containers,
-                     aeson
+                     aeson,
+                     http-common  >= 0.8.0,
+                     http-streams >= 0.8.0
 
-  hs-source-dirs:    src,tests
+  hs-source-dirs:    tests,src
   main-is:           check.hs
 
   ghc-options:       -O2
@@ -126,7 +127,7 @@ test-suite           snippet
                      base,
                      bytestring,
                      io-streams,
-                     http-streams
+                     http-streams >= 0.8.0
 
   hs-source-dirs:    tests
   main-is:           snippet.hs

--- a/src/Network/Http/Client.hs
+++ b/src/Network/Http/Client.hs
@@ -42,7 +42,7 @@
 -- main = do
 -- \    c <- 'openConnection' \"www.example.com\" 80
 --
--- \     q <- 'buildRequest' $ do
+-- \     let q = 'buildRequest' $ do
 --         'http' GET \"\/\"
 --         'setAccept' \"text/html\"
 --

--- a/src/Network/Http/Connection.hs
+++ b/src/Network/Http/Connection.hs
@@ -118,7 +118,7 @@ makeConnection h c o1 i = do
 -- @Connection@ afterwards.
 --
 -- >     x <- withConnection (openConnection "s3.example.com" 80) $ (\c -> do
--- >         q <- buildRequest $ do
+-- >         let q = buildRequest $ do
 -- >             http GET "/bucket42/object/149"
 -- >         sendRequest c q emptyBody
 -- >         ...
@@ -519,7 +519,7 @@ inputStreamBody i1 o = do
 --
 -- >     c <- openConnection "kernel.operationaldynamics.com" 58080
 -- >
--- >     q <- buildRequest $ do
+-- >     let q = buildRequest $ do
 -- >         http GET "/time"
 -- >
 -- >     sendRequest c q emptyBody

--- a/src/Network/Http/Inconvenience.hs
+++ b/src/Network/Http/Inconvenience.hs
@@ -171,7 +171,7 @@ modifyContextSSL f = do
 -- >     let url = "https://www.example.com/photo.jpg"
 -- >
 -- >     c <- establishConnection url
--- >     q <- buildRequest $ do
+-- >     let q = buildRequest $ do
 -- >         http GET url
 -- >     ...
 --
@@ -312,11 +312,11 @@ getN n r' handler = do
 
     u = parseURL r'
 
-    process c = do
-        q <- buildRequest $ do
+    q = buildRequest $ do
             http GET (path u)
             setAccept "*/*"
 
+    process c = do
         sendRequest c q emptyBody
 
         receiveResponse c (wrapRedirect u n handler)
@@ -401,12 +401,12 @@ post r' t body handler = do
 
     u = parseURL r'
 
-    process c = do
-        q <- buildRequest $ do
+    q = buildRequest $ do
             http POST (path u)
             setAccept "*/*"
             setContentType t
 
+    process c = do
         _ <- sendRequest c q body
 
         x <- receiveResponse c handler
@@ -438,12 +438,12 @@ postForm r' nvs handler = do
 
     u = parseURL r'
 
-    process c = do
-        q <- buildRequest $ do
+    q = buildRequest $ do
             http POST (path u)
             setAccept "*/*"
             setContentType "application/x-www-form-urlencoded"
 
+    process c = do
         _ <- sendRequest c q (encodedFormBody nvs)
 
         x <- receiveResponse c handler
@@ -508,12 +508,12 @@ put r' t body handler = do
 
     u = parseURL r'
 
-    process c = do
-        q <- buildRequest $ do
+    q = buildRequest $ do
             http PUT (path u)
             setAccept "*/*"
             setHeader "Content-Type" t
 
+    process c = do
         _ <- sendRequest c q body
 
         x <- receiveResponse c handler

--- a/tests/ActualSnippet.hs
+++ b/tests/ActualSnippet.hs
@@ -13,6 +13,7 @@
 
 module Main where
 
+import GHC.Conc
 import Network.Http.Client
 
 --
@@ -27,11 +28,13 @@ import qualified System.IO.Streams as Streams
 
 main :: IO ()
 main = do
+    let n = numCapabilities
+    putStrLn (show n)
     c <- openConnection "kernel.operationaldynamics.com" 58080
 
-    q <- buildRequest $ do
-        http GET "/time"
-        setAccept "text/plain"
+    let q = buildRequest $ do
+                http GET "/time"
+                setAccept "text/plain"
     putStr $ show q
             -- Requests [headers] are terminated by a double newline
             -- already. We need a better way of emitting debug

--- a/tests/BaselinePoint.hs
+++ b/tests/BaselinePoint.hs
@@ -39,9 +39,9 @@ actual :: ByteString -> IO ()
 actual x' = do
     c <- fakeConnection x'
 
-    q <- buildRequest $ do
-        http GET "/bucket42/object149"
-        setAccept "text/plain"
+    let q = buildRequest $ do
+                http GET "/bucket42/object149"
+                setAccept "text/plain"
 
     sendRequest c q emptyBody
 

--- a/tests/BasicSnippet.hs
+++ b/tests/BasicSnippet.hs
@@ -29,9 +29,9 @@ main :: IO ()
 main = do
     c <- openConnection "kernel.operationaldynamics.com" 58080
 
-    q <- buildRequest $ do
-        http GET "/time"
-        setAccept "text/plain"
+    let q = buildRequest $ do
+                http GET "/time"
+                setAccept "text/plain"
 
     sendRequest c q emptyBody
 

--- a/tests/CurrentPoint.hs
+++ b/tests/CurrentPoint.hs
@@ -25,7 +25,6 @@ import Network.Http.Client
 
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as S
-import qualified Data.ByteString.UTF8 as S
 import Debug.Trace
 import System.IO.Streams (InputStream, OutputStream, stdout)
 import qualified System.IO.Streams as Streams
@@ -39,9 +38,9 @@ actual :: ByteString -> IO ()
 actual x' = do
     c <- fakeConnection x'
 
-    q <- buildRequest $ do
-        http GET "/bucket42/object149"
-        setAccept "text/plain"
+    let q = buildRequest $ do
+                http GET "/bucket42/object149"
+                setAccept "text/plain"
 
     sendRequest c q emptyBody
 

--- a/tests/ExperimentalSnippet.hs
+++ b/tests/ExperimentalSnippet.hs
@@ -57,9 +57,9 @@ basic = do
     c <- openConnection "kernel.operationaldynamics.com" 58080
     putStrLn $ show c
 
-    q <- buildRequest $ do
-        http GET "/time"
-        setAccept "text/plain"
+    let q = buildRequest $ do
+                http GET "/time"
+                setAccept "text/plain"
     putStr $ show q
             -- Requests [headers] are terminated by a double newline
             -- already. We need a better way of emitting debug
@@ -95,11 +95,11 @@ resource = bracket
 
 doStuff :: Connection -> IO ByteString
 doStuff c = do
-    q <- buildRequest $ do
-        http PUT "/put"
-        setAccept "*/*"
-        setContentType "text/plain"
-        setContentLength 12
+    let q = buildRequest $ do
+                http PUT "/put"
+                setAccept "*/*"
+                setContentType "text/plain"
+                setContentLength 12
 
     sendRequest c q (\o ->
         Streams.write (Just "Hello World\n") o)

--- a/tests/JsonSnippet.hs
+++ b/tests/JsonSnippet.hs
@@ -48,9 +48,9 @@ main0 :: IO ()
 main0 = do
     c <- openConnection "ip.jsontest.com" 80
 
-    q <- buildRequest $ do
-        http GET "/"
-        setAccept "application/json"
+    let q = buildRequest $ do
+                http GET "/"
+                setAccept "application/json"
 
     putStr $ show q
             -- Requests [headers] are terminated by a double newline

--- a/tests/PerformanceSnippet.hs
+++ b/tests/PerformanceSnippet.hs
@@ -53,9 +53,9 @@ basic :: ByteString -> IO ()
 basic b' = do
     c <- fakeConnection b'
 
-    q <- buildRequest $ do
-        http GET "/"
-        setAccept "text/plain"
+    let q = buildRequest $ do
+                http GET "/"
+                setAccept "text/plain"
 
     sendRequest c q emptyBody
 

--- a/tests/PipeliningSnippet.hs
+++ b/tests/PipeliningSnippet.hs
@@ -35,17 +35,17 @@ main :: IO ()
 main = do
     c <- openConnection "kernel.operationaldynamics.com" 58080
 
-    q1 <- buildRequest $ do
-        http GET "/time?id=1"
-        setAccept "text/plain"
+    let q1 = buildRequest $ do
+                http GET "/time?id=1"
+                setAccept "text/plain"
 
-    q2 <- buildRequest $ do
-        http GET "/time?id=2"
-        setAccept "text/plain"
+    let q2 = buildRequest $ do
+                http GET "/time?id=2"
+                setAccept "text/plain"
 
-    q3 <- buildRequest $ do
-        http GET "/time?id=3"
-        setAccept "text/plain"
+    let q3 = buildRequest $ do
+                http GET "/time?id=3"
+                setAccept "text/plain"
 
     sendRequest c q1 emptyBody
     threadDelay 1000000

--- a/tests/SecureSocketsSnippet.hs
+++ b/tests/SecureSocketsSnippet.hs
@@ -38,9 +38,9 @@ example1 = withOpenSSL $ do
     ctx <- baselineContextSSL
     c <- openConnectionSSL ctx "api.github.com" 443
 
-    q <- buildRequest $ do
-        http GET "/users/afcowie/orgs"
-        setAccept "application/json"
+    let q = buildRequest $ do
+                http GET "/users/afcowie/orgs"
+                setAccept "application/json"
     putStr $ show q
 
     sendRequest c q emptyBody

--- a/tests/StreamsSample.hs
+++ b/tests/StreamsSample.hs
@@ -29,9 +29,9 @@ sampleViaHttpStreams :: IO ()
 sampleViaHttpStreams = do
     c <- openConnection "localhost" 80
 
-    q <- buildRequest $ do
-        http GET "/"
-        setAccept "text/html"
+    let q = buildRequest $ do
+                http GET "/"
+                setAccept "text/html"
 
     sendRequest c q emptyBody
 

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -121,9 +121,9 @@ suite = do
 testRequestTermination =
     it "terminates with a blank line" $ do
         c <- openConnection "localhost" localPort
-        q <- buildRequest $ do
-            http GET "/time"
-            setAccept "text/plain"
+        let q = buildRequest $ do
+                    http GET "/time"
+                    setAccept "text/plain"
 
         let e' = Builder.toByteString $ composeRequestBytes q "booga"
         let n = S.length e' - 4
@@ -140,8 +140,8 @@ testRequestLineFormat =
         (fakeConnection)
         (return)
         (\c -> do
-            q <- buildRequest $ do
-                http GET "/time"
+            let q = buildRequest $ do
+                        http GET "/time"
 
             let e' = Builder.toByteString $ composeRequestBytes q (cHost c)
             let l' = S.takeWhile (/= '\r') e'
@@ -159,8 +159,8 @@ fakeConnection = do
 
 testAcceptHeaderFormat =
     it "properly formats Accept header" $ do
-        q <- buildRequest $ do
-            setAccept' [("text/html", 1),("*/*", 0.0)]
+        let q = buildRequest $ do
+                    setAccept' [("text/html", 1),("*/*", 0.0)]
 
         let h = qHeaders q
         let (Just a) = lookupHeader h "Accept"
@@ -168,8 +168,8 @@ testAcceptHeaderFormat =
 
 testBasicAuthorizatonHeader =
     it "properly formats Authorization header" $ do
-        q <- buildRequest $ do
-            setAuthorizationBasic "Aladdin" "open sesame"
+        let q = buildRequest $ do
+                    setAuthorizationBasic "Aladdin" "open sesame"
 
         let h = qHeaders q
         let (Just a) = lookupHeader h "Authorization"
@@ -194,22 +194,22 @@ testConnectionHost = do
 -}
 testEnsureHostField =
     it "has a properly formatted Host header" $ do
-        q1 <- buildRequest $ do
-            http GET "/hello.txt"
+        let q1 = buildRequest $ do
+                    http GET "/hello.txt"
 
         let h1 = qHost q1
         assertEqual "Incorrect Host header" Nothing h1
 
-        q2 <- buildRequest $ do
-            http GET "/hello.txt"
-            setHostname "other.example.com" 80
+        let q2 = buildRequest $ do
+                    http GET "/hello.txt"
+                    setHostname "other.example.com" 80
 
         let h2 = qHost q2
         assertEqual "Incorrect Host header" (Just "other.example.com") h2
 
-        q3 <- buildRequest $ do
-            http GET "/hello.txt"
-            setHostname "other.example.com" 54321
+        let q3 = buildRequest $ do
+                    http GET "/hello.txt"
+                    setHostname "other.example.com" 54321
 
         let h3 = qHost q3
         assertEqual "Incorrect Host header" (Just "other.example.com:54321") h3
@@ -250,8 +250,8 @@ testChunkedEncoding =
     it "recognizes chunked transfer encoding and decodes" $ do
         c <- openConnection "localhost" localPort
 
-        q <- buildRequest $ do
-            http GET "/time"
+        let q = buildRequest $ do
+                    http GET "/time"
 
         sendRequest c q emptyBody
         receiveResponse c (\p i1 -> do
@@ -269,8 +269,8 @@ testContentLength = do
     it "recognzies fixed length message" $ do
         c <- openConnection "localhost" localPort
 
-        q <- buildRequest $ do
-            http GET "/static/statler.jpg"
+        let q = buildRequest $ do
+                    http GET "/static/statler.jpg"
 
         sendRequest c q emptyBody
 
@@ -301,8 +301,8 @@ testContentLength = do
 
     it "reads body without Content-Length or Transfer-Encoding" $ do
         c <- fakeConnectionHttp10
-        q <- buildRequest $ do
-            http GET "/fake"
+        let q = buildRequest $ do
+                    http GET "/fake"
         sendRequest c q emptyBody
         receiveResponse c (\_ i1 -> do
             (i2, getCount) <- Streams.countInput i1
@@ -338,8 +338,8 @@ testDevoidOfContent = do
     it "handles 204 No Content response without Content-Length"
       $ timeout_ 2 $ do
         (c, mv) <- fakeConnectionNoContent
-        q <- buildRequest $ do
-            http GET "/fake"
+        let q = buildRequest $ do
+                    http GET "/fake"
         sendRequest c q emptyBody
         receiveResponse c (\_ i1 -> do
             (i2, getCount) <- Streams.countInput i1
@@ -386,9 +386,9 @@ testCompressedResponse =
     it "recognizes gzip content encoding and decompresses" $ do
         c <- openConnection "localhost" localPort
 
-        q <- buildRequest $ do
-            http GET "/static/hello.html"
-            setHeader "Accept-Encoding" "gzip"
+        let q = buildRequest $ do
+                    http GET "/static/hello.html"
+                    setHeader "Accept-Encoding" "gzip"
 
         sendRequest c q emptyBody
 
@@ -418,9 +418,9 @@ testExpectationContinue =
     it "sends expectation and handles 100 response" $ do
         c <- openConnection "localhost" localPort
 
-        q <- buildRequest $ do
-            http PUT "/resource/x149"
-            setExpectContinue
+        let q = buildRequest $ do
+                    http PUT "/resource/x149"
+                    setExpectContinue
 
         sendRequest c q (\o -> do
             Streams.write (Just (Builder.fromString "Hello world\n")) o)
@@ -469,10 +469,10 @@ testSendBodyFor meth =
     it ("Sends a request body for " ++ show meth) $ do
         c <- openConnection "localhost" localPort
 
-        q <- buildRequest $ do
-            http meth "/size"
-            setContentType "text/plain"
-            setTransferEncoding
+        let q = buildRequest $ do
+                    http meth "/size"
+                    setContentType "text/plain"
+                    setTransferEncoding
 
         sendRequest c q (\o -> do
             Streams.write (Just (Builder.fromString "a request")) o)
@@ -651,8 +651,8 @@ testEstablishConnection =
         let url = S.concat ["http://", localhost, "/static/statler.jpg"]
 
         x' <- withConnection (establishConnection url) $ (\c -> do
-            q <- buildRequest $ do
-                http GET "/static/statler.jpg"
+            let q = buildRequest $ do
+                        http GET "/static/statler.jpg"
                     -- TODO be nice if we could replace that with 'url';
                     -- fix the routeRequests function in TestServer maybe?
             sendRequest c q emptyBody


### PR DESCRIPTION
There's no need for IO, so make the function which runs a
RequestBuilder action a pure one.

This is a breaking change, unfortunately, but addresses the driving
concern in #9 and #48 and also afcowie/http-common#9. There's a branch on [http-common](https://github.com/afcowie/http-common) which implements this, obviously.

Good idea? Probably long overdue.

AfC
