### PR TITLE
Expose function to extract code & body from HttpClientError

### DIFF
--- a/src/Network/Http/Client.hs
+++ b/src/Network/Http/Client.hs
@@ -139,6 +139,7 @@ module Network.Http.Client (
     debugHandler,
     concatHandler,
     concatHandler',
+    httpClientErrorCodeBody,
     HttpClientError,
     jsonHandler,
 

--- a/src/Network/Http/Inconvenience.hs
+++ b/src/Network/Http/Inconvenience.hs
@@ -28,6 +28,7 @@ module Network.Http.Inconvenience (
     baselineContextSSL,
     concatHandler',
     jsonHandler,
+    httpClientErrorCodeBody,
     TooManyRedirects(..),
     HttpClientError(..),
 
@@ -541,6 +542,9 @@ instance Exception HttpClientError
 
 instance Show HttpClientError where
     show (HttpClientError s msg) = Prelude.show s ++ " " ++ S.unpack msg
+
+httpClientErrorCodeBody :: HttpClientError -> (Int, ByteString)
+httpClientErrorCodeBody (HttpClientError c b) = (c, b)
 
 {-
     There should probably also be HttpServerError and maybe even


### PR DESCRIPTION
There's currently no way to use HttpClientError objects other than calling `show` on it, and that concats together the response code and response body. If we want to work with them separately, we'd have to write a parsing function in our logic that extracts both, **or** add a method to http-streams that just extracts the internal parameters from the HttpClientError object.
