### PR TITLE
Export HttpClientError constructor so we can pattern match on http error...

### DIFF
--- a/src/Network/Http/Client.hs
+++ b/src/Network/Http/Client.hs
@@ -139,7 +139,7 @@ module Network.Http.Client (
     debugHandler,
     concatHandler,
     concatHandler',
-    HttpClientError,
+    HttpClientError(..),
     jsonHandler,
 
     -- * Resource cleanup


### PR DESCRIPTION
... objects
