### PR TITLE
Add helper functions for sending JSON objects

### DIFF
--- a/http-streams.cabal
+++ b/http-streams.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.24
 name:                http-streams
-version:             0.8.7.3
+version:             0.8.8.1
 synopsis:            An HTTP client using io-streams
 description:
  An HTTP client, using the Snap Framework's 'io-streams' library to

--- a/lib/Network/Http/Client.hs
+++ b/lib/Network/Http/Client.hs
@@ -126,6 +126,7 @@ module Network.Http.Client (
     getHostname,
     sendRequest,
     emptyBody,
+    simpleBody,
     fileBody,
     inputStreamBody,
     encodedFormBody,

--- a/lib/Network/Http/Client.hs
+++ b/lib/Network/Http/Client.hs
@@ -129,6 +129,7 @@ module Network.Http.Client (
     fileBody,
     inputStreamBody,
     encodedFormBody,
+    jsonBody,
 
     -- * Processing HTTP response
     receiveResponse,

--- a/lib/Network/Http/Connection.hs
+++ b/lib/Network/Http/Connection.hs
@@ -537,7 +537,6 @@ fileBody :: FilePath -> OutputStream Builder -> IO ()
 fileBody p o = do
     Streams.withFileAsInput p (\i -> inputStreamBody i o)
 
-
 --
 -- | Read from a pre-existing 'InputStream' and pipe that through to the
 -- connection to the server. This is useful in the general case where

--- a/lib/Network/Http/Connection.hs
+++ b/lib/Network/Http/Connection.hs
@@ -33,6 +33,7 @@ module Network.Http.Connection (
     unsafeReceiveResponse,
     UnexpectedCompression,
     emptyBody,
+    simpleBody,
     fileBody,
     inputStreamBody,
     debugHandler,
@@ -514,6 +515,16 @@ unsafeReceiveResponse c handler = do
 emptyBody :: OutputStream Builder -> IO ()
 emptyBody _ = return ()
 
+{-|
+Sometimes you just want to send some bytes to the server as a the body of your
+request. This is easy to use, but if you're doing anything massive use
+'inputStreamBody'; if you're sending a file use 'fileBody'; if you have an
+object that needs to be sent as JSON use 'jsonBody'
+-}
+simpleBody :: ByteString -> OutputStream Builder -> IO ()
+simpleBody x' o = do
+    let b = Builder.fromByteString x'
+    Streams.write (Just b) o
 
 --
 -- | Specify a local file to be sent to the server as the body of the

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -114,6 +114,7 @@ suite = do
         testEstablishConnection
         testParsingJson1
         testParsingJson2
+        testPostWithSimple
         testPostWithJson
 
     describe "Corner cases in protocol compliance" $ do
@@ -726,6 +727,20 @@ instance ToJSON GrossDomesticProduct where
     toJSON (GrossDomesticProduct l d) = object
                                ["label" .= l,
                                 "data"  .= d]
+
+
+testPostWithSimple =
+    it "PUT with static data" $ do
+        let url = S.concat ["http://", localhost, "/resource/y98"]
+
+        x' <- put url "text/plain" (simpleBody b') concatHandler
+
+        assertEqual "Object was encoded to JSON as expected"
+                    "Hello"
+                    x'
+      where
+        b' :: ByteString
+        b' = S.pack "Hello"
 
 testPostWithJson =
     it "PUT with json data" $ do


### PR DESCRIPTION
Introduce `jsonBody` for sending types with ToJSON instances as JSON for a request body.

Introduce `simpleBody` tor sending a straight ByteString as is for a request body.