### PR TITLE
Rename concatHandler to simpleHandler

### DIFF
--- a/http-streams.cabal
+++ b/http-streams.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.24
 name:                http-streams
-version:             0.8.8.1
+version:             0.8.8.2
 synopsis:            An HTTP client using io-streams
 description:
  An HTTP client, using the Snap Framework's 'io-streams' library to

--- a/lib/Network/Http/Client.hs
+++ b/lib/Network/Http/Client.hs
@@ -142,8 +142,8 @@ module Network.Http.Client (
     getStatusMessage,
     getHeader,
     debugHandler,
-    concatHandler,
-    concatHandler',
+    simpleHandler,
+    simpleHandler',
     HttpClientError(..),
     jsonHandler,
 
@@ -181,6 +181,8 @@ module Network.Http.Client (
     getHeadersFull,
 
     -- * Deprecated
+    concatHandler,
+    concatHandler',
     getRequestHeaders
 ) where
 

--- a/lib/Network/Http/Connection.hs
+++ b/lib/Network/Http/Connection.hs
@@ -37,6 +37,7 @@ module Network.Http.Connection (
     fileBody,
     inputStreamBody,
     debugHandler,
+    simpleHandler,
     concatHandler
 ) where
 
@@ -614,7 +615,7 @@ debugHandler p i = do
 -- as follows:
 --
 -- >    ...
--- >    x' <- receiveResponse c concatHandler
+-- >    x' <- receiveResponse c simpleHandler
 -- >    ...
 --
 -- The methods in the convenience API all take a function to handle the
@@ -622,7 +623,7 @@ debugHandler p i = do
 -- call underlying the request. Thus this utility function can be used
 -- for 'get' as well:
 --
--- >    x' <- get "http://www.example.com/document.txt" concatHandler
+-- >    x' <- get "http://www.example.com/document.txt" simpleHandler
 --
 -- Either way, the usual caveats about allocating a
 -- single object from streaming I/O apply: do not use this if you are
@@ -633,15 +634,15 @@ debugHandler p i = do
 -- response's HTTP status code. You're almost certainly better off
 -- writing your own handler function.
 --
-{-
-    I'd welcome a better name for this function.
--}
-concatHandler :: Response -> InputStream ByteString -> IO ByteString
-concatHandler _ i1 = do
+simpleHandler :: Response -> InputStream ByteString -> IO ByteString
+simpleHandler _ i1 = do
     i2 <- Streams.map Builder.fromByteString i1
     x <- Streams.fold mappend mempty i2
     return $ Builder.toByteString x
 
+concatHandler :: Response -> InputStream ByteString -> IO ByteString
+concatHandler = simpleHandler
+{-# DEPRECATED concatHandler "Use simpleHandler instead" #-}
 
 --
 -- | Shutdown the connection. You need to call this release the

--- a/lib/Network/Http/Inconvenience.hs
+++ b/lib/Network/Http/Inconvenience.hs
@@ -27,6 +27,7 @@ module Network.Http.Inconvenience (
     encodedFormBody,
     put,
     baselineContextSSL,
+    simpleHandler',
     concatHandler',
     jsonBody,
     jsonHandler,
@@ -540,14 +541,17 @@ put r' t body handler = do
 -- entire response body as a single ByteString, but will throw
 -- 'HttpClientError' if the response status code was other than @2xx@.
 --
-concatHandler' :: Response -> InputStream ByteString -> IO ByteString
-concatHandler' p i =
+simpleHandler' :: Response -> InputStream ByteString -> IO ByteString
+simpleHandler' p i =
     if s >= 300
         then throw (HttpClientError s m)
-        else concatHandler p i
+        else simpleHandler p i
   where
     s = getStatusCode p
     m = getStatusMessage p
+
+concatHandler' :: Response -> InputStream ByteString -> IO ByteString
+concatHandler' = simpleHandler'
 
 data HttpClientError = HttpClientError Int ByteString
         deriving (Typeable)


### PR DESCRIPTION
Rename the useful but poorly named `concatHandler` to `simpleHandler`, matching the convention recently created by the addition of `simpleBody` on the sending side. No one cares they're concatenating a bunch of chunks if they just want all the bytes coming down.