### PR TITLE
Minor updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* _v0.8.9_
+    Ongoing maintenance continues, including support for GHC 9.2
+
 * _v0.8.6_  
 	Internal modules are exposed. Mostly so the test suite would only
 	depend on the library and not the code directly, but occasionally

--- a/http-streams.cabal
+++ b/http-streams.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.24
 name:                http-streams
-version:             0.8.9.6
+version:             0.8.9.7
 synopsis:            An HTTP client using io-streams
 description:
  An HTTP client, using the Snap Framework's 'io-streams' library to
@@ -15,9 +15,9 @@ license:             BSD3
 license-file:        LICENSE
 author:              Andrew Cowie <istathar@gmail.com>
 maintainer:          Andrew Cowie <istathar@gmail.com>
-copyright:           © 2012-2022 Athae Eredh Siniath and Others
+copyright:           © 2012-2023 Athae Eredh Siniath and Others
 category:            Web, IO-Streams
-tested-with:         GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.1
+tested-with:         GHC == 8.10.7, GHC == 9.2.5
 stability:           experimental
 homepage:            https://github.com/aesiniath/http-streams/
 bug-reports:         https://github.com/aesiniath/http-streams/issues

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,16 +1,12 @@
-resolver: lts-18.23
+resolver: lts-20.10
 
 packages:
 - .
 
 extra-deps:
-- aeson-2.0.3.0
-- attoparsec-0.14.4
-- hashable-1.4.0.2
-- OneTuple-0.3.1
-- semialign-1.2.0.1
-- text-short-0.1.5
-- time-compat-1.9.6.1
+- readable-0.3.1
+- snap-core-1.0.5.0
+- snap-server-1.1.2.0
 
 flags:
   http-streams:


### PR DESCRIPTION
Tweak the build configuration in the top-level _stack.yaml_ used for testing to reflect that we now build find with `lts-20.x` and GHC 9.2.5