### PR TITLE
Add support for aeson 2.2

### DIFF
--- a/http-streams.cabal
+++ b/http-streams.cabal
@@ -61,7 +61,8 @@ library
                      transformers,
                      text,
                      unordered-containers,
-                     aeson < 2.2,
+                     aeson < 2.3,
+                     attoparsec-aeson < 2.3
                      http-common >= 0.8.3.4
   if flag(network-uri)
     build-depends: network-uri >= 2.6, network >= 2.6

--- a/lib/Network/Http/Inconvenience.hs
+++ b/lib/Network/Http/Inconvenience.hs
@@ -51,12 +51,8 @@ import qualified Blaze.ByteString.Builder as Builder (
  )
 import qualified Blaze.ByteString.Builder.Char8 as Builder (fromString)
 import Control.Exception (Exception, bracket, throw)
-#if !MIN_VERSION_aeson(2,2,0)
-import Data.Aeson (FromJSON, Result (..), ToJSON, encode, fromJSON, json')
-#else
 import Data.Aeson (FromJSON, Result (..), ToJSON, encode, fromJSON)
 import Data.Aeson.Parser (json')
-#endif
 import Data.Bits (Bits (..))
 import Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as S

--- a/lib/Network/Http/Inconvenience.hs
+++ b/lib/Network/Http/Inconvenience.hs
@@ -51,7 +51,12 @@ import qualified Blaze.ByteString.Builder as Builder (
  )
 import qualified Blaze.ByteString.Builder.Char8 as Builder (fromString)
 import Control.Exception (Exception, bracket, throw)
+#if !MIN_VERSION_aeson(2,2,0)
 import Data.Aeson (FromJSON, Result (..), ToJSON, encode, fromJSON, json')
+#else
+import Data.Aeson (FromJSON, Result (..), ToJSON, encode, fromJSON)
+import Data.Aeson.Parser (json')
+#endif
 import Data.Bits (Bits (..))
 import Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as S

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,6 +5,7 @@ packages:
 - .
 
 extra-deps:
+- attoparsec-aeson-2.1.0.0
 - snap-core-1.0.5.1
 - snap-server-1.1.2.1
 

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -33,7 +33,6 @@ import Data.Aeson (
     ToJSON,
     Value (..),
     encode,
-    json,
     object,
     parseJSON,
     toJSON,


### PR DESCRIPTION
The functionality of `json'` was moved to the module Data.Aeson.Parser within the package attoparsec-aeson.

This PR is essentially a rebase of #134, resolving the conflicts.

Closes #134 
Closes #136 
See also #135 