### PR TITLE
Inconvenience: update Fedora ca-file

### DIFF
--- a/lib/Network/Http/Inconvenience.hs
+++ b/lib/Network/Http/Inconvenience.hs
@@ -276,7 +276,7 @@ baselineContextSSL = withOpenSSL $ do
     fedora <- doesDirectoryExist "/etc/pki/tls"
     if fedora
         then do
-            SSL.contextSetCAFile ctx "/etc/pki/tls/certs/ca-bundle.crt"
+            SSL.contextSetCAFile ctx "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
         else do
             SSL.contextSetCADirectory ctx "/etc/ssl/certs"
     SSL.contextSetVerificationMode ctx $ SSL.VerifyPeer True True Nothing


### PR DESCRIPTION
In Fedora 44, `/etc/pki/tls/certs/ca-bundle.crt` is being replaced by `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`.

See https://fedoraproject.org/wiki/Changes/droppingOfCertPemFile

See also https://github.com/kazu-yamamoto/crypton-certificate/issues/17 which I also opened.